### PR TITLE
since 0.4.0 bind_exporete uses long flags (kingpin.v2)

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -17,7 +17,7 @@ prometheus_bind_exporter_loglevel: '{{ prometheus_loglevel }}'
 prometheus_bind_exporter_weblisten: '{{ prometheus_bind_exporter_listen_ip }}:{{ prometheus_bind_exporter_listen_port }}'
 prometheus_bind_exporter_listen_port: '9119'
 prometheus_bind_exporter_listen_ip: ''
-prometheus_bind_exporter_version: '0.3.0'
+prometheus_bind_exporter_version: '0.6.0'
 prometheus_bind_exporter_targeturl: 'http://127.0.0.1:8053/'
 
 prometheus_bind_pid_file: '/run/named/named.pid'

--- a/templates/bind_exporter.defaults.j2
+++ b/templates/bind_exporter.defaults.j2
@@ -4,8 +4,8 @@ START=yes
 
 #
 STARTUP_ARGS=" \
-      -bind.stats-groups server,view,tasks \
-      -bind.pid-file {{ prometheus_bind_pid_file }} \
-      -bind.stats-url {{ prometheus_bind_exporter_targeturl }} \
-      -web.listen-address {{ prometheus_bind_exporter_weblisten }} \
+      --bind.stats-groups server,view,tasks \
+      --bind.pid-file {{ prometheus_bind_pid_file }} \
+      --bind.stats-url {{ prometheus_bind_exporter_targeturl }} \
+      --web.listen-address {{ prometheus_bind_exporter_weblisten }} \
       "


### PR DESCRIPTION
- since 0.4.0 bind_exporete uses long flags (kingpin.v2)
- use release 0.6.0 by default